### PR TITLE
fix issue#3 Store GOBJ: Extended presence flags

### DIFF
--- a/src/util/kmpData.js
+++ b/src/util/kmpData.js
@@ -67,6 +67,7 @@ class KmpData
 		let cannonPoints = []
 		let trackInfo = {}
 		let unhandledSectionData = []
+		let extraDatas = []
 		
 		for (let sectionOffset of sectionOffsets)
 		{
@@ -302,10 +303,12 @@ class KmpData
 					break
 				}
 			}
+			extraDatas.push({ id: sectionId, vaule: extraData })
 		}
 		
 		return {
 			unhandledSectionData,
+			extraDatas,
 			startPoints, finishPoints,
 			enemyPoints, enemyPaths,
 			itemPoints, itemPaths,
@@ -322,6 +325,7 @@ class KmpData
 		let kmp = new KmpData()
 		kmp.trackInfo = kmpData.trackInfo
 		kmp.unhandledSectionData = kmpData.unhandledSectionData
+		kmp.extraDatas = kmpData.extraDatas
 		
 		for (let i = 0; i < kmpData.startPoints.length; i++)
 		{
@@ -582,10 +586,12 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionKtptOrder * 4)
 		w.writeUInt32(sectionKtptAddr - headerEndAddr)
 		
+		let scetionMagicStr = "KTPT"
 		w.seek(sectionKtptAddr)
-		w.writeAscii("KTPT")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(this.startPoints.nodes.length)
-		w.writeUInt16(0)
+		let extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let p of this.startPoints.nodes)
 		{
 			w.writeFloat32(p.pos.x)
@@ -615,10 +621,12 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionEnptOrder * 4)
 		w.writeUInt32(sectionEnptAddr - headerEndAddr)
 		
+		scetionMagicStr = "ENPT"
 		w.seek(sectionEnptAddr)
-		w.writeAscii("ENPT")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(enemyPoints.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let p of enemyPoints)
 		{
 			w.writeFloat32(p.pos.x)
@@ -636,10 +644,13 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionEnphOrder * 4)
 		w.writeUInt32(sectionEnphAddr - headerEndAddr)
 		
+		scetionMagicStr = "ENPH"
 		w.seek(sectionEnphAddr)
-		w.writeAscii("ENPH")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(enemyPaths.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
+
 		for (let path of enemyPaths)
 		{
 			if (path.nodes.length > 0xff)
@@ -693,10 +704,12 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionItptOrder * 4)
 		w.writeUInt32(sectionItptAddr - headerEndAddr)
 		
+		scetionMagicStr = "ITPT"
 		w.seek(sectionItptAddr)
-		w.writeAscii("ITPT")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(itemPoints.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let p of itemPoints)
 		{
 			w.writeFloat32(p.pos.x)
@@ -713,10 +726,12 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionItphOrder * 4)
 		w.writeUInt32(sectionItphAddr - headerEndAddr)
 		
+		scetionMagicStr = "ITPH"
 		w.seek(sectionItphAddr)
-		w.writeAscii("ITPH")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(itemPaths.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let path of itemPaths)
 		{
 			if (path.nodes.length > 0xff)
@@ -770,10 +785,12 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionCkptOrder * 4)
 		w.writeUInt32(sectionCkptAddr - headerEndAddr)
 		
+		scetionMagicStr = "CKPT"
 		w.seek(sectionCkptAddr)
-		w.writeAscii("CKPT")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(checkpointPoints.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let i = 0; i < checkpointPoints.length; i++)
 		{
 			let p = checkpointPoints[i]
@@ -803,10 +820,12 @@ class KmpData
 		w.seek(sectionOffsetsAddr + sectionCkphOrder * 4)
 		w.writeUInt32(sectionCkphAddr - headerEndAddr)
 		
+		scetionMagicStr = "CKPH"
 		w.seek(sectionCkphAddr)
-		w.writeAscii("CKPH")
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(checkpointPaths.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let path of checkpointPaths)
 		{
 			if (path.nodes.length > 0xff)
@@ -850,9 +869,11 @@ class KmpData
 		w.writeUInt32(sectionGobjAddr - headerEndAddr)
 		
 		w.seek(sectionGobjAddr)
-		w.writeAscii("GOBJ")
+		scetionMagicStr = "GOBJ"
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(this.objects.nodes.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let i = 0; i < this.objects.nodes.length; i++)
 		{
 			let obj = this.objects.nodes[i]
@@ -920,9 +941,11 @@ class KmpData
 		w.writeUInt32(sectionJgptAddr - headerEndAddr)
 		
 		w.seek(sectionJgptAddr)
-		w.writeAscii("JGPT")
+		scetionMagicStr = "JGPT"
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(this.respawnPoints.nodes.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let i = 0; i < this.respawnPoints.nodes.length; i++)
 		{
 			let p = this.respawnPoints.nodes[i]
@@ -944,9 +967,11 @@ class KmpData
 		w.writeUInt32(sectionCnptAddr - headerEndAddr)
 		
 		w.seek(sectionCnptAddr)
-		w.writeAscii("CNPT")
+		scetionMagicStr = "CNPT"
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(this.cannonPoints.nodes.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let p of this.cannonPoints.nodes)
 		{
 			w.writeFloat32(p.pos.x)
@@ -966,9 +991,11 @@ class KmpData
 		w.writeUInt32(sectionMsptAddr - headerEndAddr)
 		
 		w.seek(sectionMsptAddr)
-		w.writeAscii("MSPT")
+		scetionMagicStr = "MSPT"
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(this.finishPoints.nodes.length)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		for (let p of this.finishPoints.nodes)
 		{
 			w.writeFloat32(p.pos.x)
@@ -988,9 +1015,11 @@ class KmpData
 		w.writeUInt32(sectionStgiAddr - headerEndAddr)
 		
 		w.seek(sectionStgiAddr)
-		w.writeAscii("STGI")
+		scetionMagicStr = "STGI"
+		w.writeAscii(scetionMagicStr)
 		w.writeUInt16(1)
-		w.writeUInt16(0)
+		extraData = this.extraDatas.find(s => s.id == scetionMagicStr)
+		w.writeUInt16(extraData.vaule)
 		w.writeByte(this.trackInfo.lapCount)
 		w.writeByte(this.trackInfo.polePosition)
 		w.writeByte(this.trackInfo.driverDistance)
@@ -1011,6 +1040,7 @@ class KmpData
 	constructor()
 	{
 		this.unhandledSectionData = []
+		this.extraDatas = []
 		
 		this.startPoints = new NodeGraph()
 		this.startPoints.onAddNode = (node) =>
@@ -1219,6 +1249,7 @@ class KmpData
 		let cloned = new KmpData()
 		cloned.trackInfo = this.trackInfo
 		cloned.unhandledSectionData = this.unhandledSectionData
+		cloned.extraDatas = this.extraDatas
 		cloned.startPoints = this.startPoints.clone()
 		cloned.finishPoints = this.finishPoints.clone()
 		cloned.enemyPoints = this.enemyPoints.clone()

--- a/src/util/kmpData.js
+++ b/src/util/kmpData.js
@@ -1217,6 +1217,7 @@ class KmpData
 	clone()
 	{
 		let cloned = new KmpData()
+		cloned.trackInfo = this.trackInfo
 		cloned.unhandledSectionData = this.unhandledSectionData
 		cloned.startPoints = this.startPoints.clone()
 		cloned.finishPoints = this.finishPoints.clone()


### PR DESCRIPTION
these changes "Copy" column of "Values for padding" to ✔(means supporting). 
https://wiki.tockdom.com/wiki/Extended_presence_flags/Software_Overview#KMP_Tools

Wiimm claims KMP editing tools "must store padding of GOBJ section values".
https://wiki.tockdom.com/wiki/Extended_presence_flags/Implementation_Hints#Reference-Id_.28Padding.29
It's means this tool must store "ExtraData" of "GOBJ".

thus I changed store ExtraDatas of GOBJ.
and I expand it to any sections(KTPT, ENPT, ENPH etc...) ExtraData.
It's for other sections expand in the _future_.